### PR TITLE
python to beta

### DIFF
--- a/data/curriculum.yaml
+++ b/data/curriculum.yaml
@@ -60,7 +60,7 @@ curricula:
   ref: https://librarycarpentry.org/lc-python-intro/reference.html
   inst_notes: https://librarycarpentry.org/lc-python-intro/guide/
   maintainers: Cody Hennesy, Tim Dennis
-  status: Alpha
+  status: Beta
   category: extended
 
 


### PR DESCRIPTION
Addresses (but doesn't close) issue #52. 

Update LC Python status to Beta on lessons page to match status on the lesson itself. 
