### PR TITLE
move Wikidata lesson to extended curriculum

### DIFF
--- a/data/curriculum.yaml
+++ b/data/curriculum.yaml
@@ -154,8 +154,8 @@ curricula:
   ref: https://librarycarpentry.github.io/lc-wikidata/reference.html
   inst_notes: https://librarycarpentry.github.io/lc-wikidata/instructor/instructor-notes.html
   maintainers: Rabea Müller, Shelby Watson
-  status: Conceptual
-  category: conceptual
+  status: Alpha
+  category: extended
 
 - lessonname: FAIR Data & Software
   site: https://librarycarpentry.github.io/lc-fair-research/


### PR DESCRIPTION
Resolves #51 

@LibraryCarpentry/governance-committee are you happy for this lesson to move from Conceptual to Extended curriculum? 