### PR TITLE
rm wikidata lesson

### DIFF
--- a/data/curriculum.yaml
+++ b/data/curriculum.yaml
@@ -148,15 +148,6 @@ curricula:
   status: Retired
   category: retired
 
-- lessonname: Wikidata
-  site: https://librarycarpentry.github.io/lc-wikidata/
-  repo: https://github.com/LibraryCarpentry/lc-wikidata
-  ref: https://librarycarpentry.github.io/lc-wikidata/reference.html
-  inst_notes: https://librarycarpentry.github.io/lc-wikidata/instructor/instructor-notes.html
-  maintainers: Rabea Müller, Shelby Watson
-  status: Conceptual
-  category: conceptual
-
 - lessonname: FAIR Data & Software
   site: https://librarycarpentry.github.io/lc-fair-research/
   repo: https://github.com/LibraryCarpentry/lc-fair-research


### PR DESCRIPTION
As noted in https://github.com/LibraryCarpentry/librarycarpentry.org/pull/72#issuecomment-3542104985, the wikidata lesson would be removed from our website if the issue about its status was not resolved by 5 December 2025.  After giving a bit of a grace period as many people have likely been on holiday leave, this PR removes the wikidata lesson from the LC website.

We can add it back whenever the status is confirmed.