### PR TITLE
Update curriculum.yaml

### DIFF
--- a/data/curriculum.yaml
+++ b/data/curriculum.yaml
@@ -70,7 +70,7 @@ curricula:
   ref: https://librarycarpentry.github.io/lc-data-intro-archives/reference.html
   inst_notes: https://librarycarpentry.github.io/lc-data-intro-archives/instructor/instructor-notes.html
   maintainers: Katherine Koziar, Senn Oon
-  status: Alpha
+  status: Beta
   category: extended
 
 - lessonname: Introduction to R
@@ -79,7 +79,7 @@ curricula:
   ref: https://librarycarpentry.github.io/lc-r/reference.html
   inst_notes: https://librarycarpentry.github.io/lc-r/instructor/instructor-notes.html
   maintainers: Jia Qi Beh, Tim Dennis, Nicky Garland
-  status: Alpha
+  status: Beta
   category: extended
 
 
@@ -89,7 +89,7 @@ curricula:
   ref: https://librarycarpentry.github.io/lc-marcedit/reference.html
   inst_notes: https://librarycarpentry.github.io/lc-marcedit/instructor/instructor-notes.html
   maintainers: Jennifer Eustis*, Abigail Sparling, Owen Stephens (looking for Maintainers)
-  status: Alpha
+  status: Beta
   category: extended
 
 


### PR DESCRIPTION
Changing MarcEdit, R, and Intro to Data for Archivists lessons to Beta per @LibraryCarpentry/governance-committee decision. See [2026-03-minutes] (https://github.com/LibraryCarpentry/governance/pull/45/changes/5aa6d51dc9886155dd5433bb3a5f9806b44cd315) for details (still a PR as of posting).
